### PR TITLE
Abstract London Underground information from watch-side logic

### DIFF
--- a/watchapps/tube-status/package-lock.json
+++ b/watchapps/tube-status/package-lock.json
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/watchapps/tube-status/package.json
+++ b/watchapps/tube-status/package.json
@@ -37,12 +37,16 @@
     "projectType": "native",
     "uuid": "5120531c-9d73-4852-b26d-3d3cee90d92a",
     "messageKeys": [
-      "LineIndex",
-      "LineType",
+      "LineStatusIndex",
       "LineStatus",
       "LineReason",
       "FlagIsComplete",
-      "FlagLineCount"
+      "FlagLineCount",
+      "ConfigLineIndex",
+      "ConfigLineName",
+      "ConfigLineColor",
+      "ConfigLineStriped",
+      "LineStatusSeverity"
     ],
     "enableMultiJS": true,
     "displayName": "Tube Status",

--- a/watchapps/tube-status/src/c/config.h
+++ b/watchapps/tube-status/src/c/config.h
@@ -2,27 +2,14 @@
 
 #include <pebble.h>
 
-// Order is very important - must match JS side
-typedef enum {
-  LineTypeBakerloo = 0,
-  LineTypeCentral,
-  LineTypeCircle,
-  LineTypeDistrict,
-  LineTypeDLR,
-  LineTypeElizabeth,
-  LineTypeHammersmithAndCity,
-  LineTypeJubilee,
-  LineTypeLiberty,
-  LineTypeLioness,
-  LineTypeMetropolitan,
-  LineTypeMildmay,
-  LineTypeNorthern,
-  LineTypePicadilly,
-  LineTypeSuffragette,
-  LineTypeVictoria,
-  LineTypeWaterlooAndCity,
-  LineTypeWeaver,
-  LineTypeWindrush,
+// Aplite should not go over 25 lines, add a condition we if add a transit system that would ever have more than 25
+// outages at once. 
+// If regular/nightly service closures exceed this amount for a line, they may need filtered out in the backend.
+#define MAX_LINES 25
 
-  LineTypeMax
-} LineType;
+// Status severity levels for visual indication
+typedef enum {
+  StatusSeverityGood = 0,
+  StatusSeverityWarning = 1,
+  StatusSeveritySevere = 2
+} StatusSeverity;

--- a/watchapps/tube-status/src/c/modules/data.h
+++ b/watchapps/tube-status/src/c/modules/data.h
@@ -5,25 +5,34 @@
 #include "../config.h"
 
 typedef struct {
-  int index;  // Unused?
-  int type;
+  bool configured;
+  char name[32];
+  uint32_t color;
+  bool striped;
+} LineConfig;
+
+typedef struct {
+  int index;
   char state[32];
   char reason[512];
+  StatusSeverity severity;
 } LineData;
 
 void data_init();
 
 void data_deinit();
 
-char* data_get_line_name(int type);
+void data_set_line_config(int index, const char *name, uint32_t color, bool striped);
 
-LineData* data_get_line(int index);
+char *data_get_line_name(int index);
 
-GColor data_get_line_color(int type);
+LineData *data_get_line(int index);
+
+GColor data_get_line_color(int index);
 
 GColor data_get_line_state_color(int index);
 
-bool data_get_line_color_is_striped(int type);
+bool data_get_line_color_is_striped(int index);
 
 void data_set_progress(int progress);
 
@@ -36,3 +45,5 @@ bool data_get_line_has_reason(int index);
 int data_get_progress_max();
 
 int data_get_lines_received();
+
+int data_get_configured_line_count();

--- a/watchapps/tube-status/src/c/windows/rect/line_window.c
+++ b/watchapps/tube-status/src/c/windows/rect/line_window.c
@@ -62,14 +62,14 @@ void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_in
 
   // Line color
   int line_color_x = center.x - (STRIPE_WIDTH / 2);
-  graphics_context_set_fill_color(ctx, data_get_line_color(line_data->type));
+  graphics_context_set_fill_color(ctx, data_get_line_color(line_data->index));
   graphics_fill_rect(
     ctx,
     GRect(line_color_x, bounds.origin.y, STRIPE_WIDTH, bounds.size.h),
     GCornerNone,
     0
   );
-  if (data_get_line_color_is_striped(line_data->type)) {
+  if (data_get_line_color_is_striped(line_data->index)) {
     graphics_context_set_fill_color(ctx, GColorWhite);
     graphics_fill_rect(
       ctx,
@@ -95,7 +95,7 @@ void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_in
   graphics_context_set_text_color(ctx, GColorBlack);
   graphics_draw_text(
     ctx,
-    data_get_line_name(line_data->type),
+    data_get_line_name(line_data->index),
     scalable_get_font(SFI_Medium),
     scalable_grect_pp(
       GRect(220, -40, 750, 200),
@@ -128,7 +128,7 @@ void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_in
       GCornerNone,
       0
     );
-    
+
     // Arrow
     graphics_draw_text(
       ctx,

--- a/watchapps/tube-status/src/c/windows/round/line_window.c
+++ b/watchapps/tube-status/src/c/windows/round/line_window.c
@@ -207,7 +207,7 @@ void line_window_push() {
   window_stack_push(s_window, true);
 
   // Begin with the first line
-  s_selected_line = LineTypeBakerloo;
+  s_selected_line = 0;
   layer_mark_dirty(s_ring_layer);
 }
 #endif

--- a/watchapps/tube-status/src/ts/backends/index.ts
+++ b/watchapps/tube-status/src/ts/backends/index.ts
@@ -1,0 +1,3 @@
+export { londonUndergroundBackend } from './londonunderground';
+export type { TransitBackend, LineConfig, LineStatus as GenericLineData } from './type';
+export { StatusSeverity } from './type';

--- a/watchapps/tube-status/src/ts/backends/londonunderground.ts
+++ b/watchapps/tube-status/src/ts/backends/londonunderground.ts
@@ -1,0 +1,175 @@
+import { TransitBackend, LineConfig, LineStatus, StatusSeverity } from './type';
+
+// API data type
+type TfLApiResult = {
+  id: string;
+  lineStatuses: {
+    statusSeverity: number;
+    statusSeverityDescription: string;
+    reason?: string;
+  }[];
+};
+
+/**
+ * London Underground / TfL transit backend
+ */
+class LondonUndergroundBackend extends TransitBackend {
+  readonly id = 'tfl';
+  readonly name = 'London Underground';
+
+  private readonly MODES = ['tube', 'dlr', 'elizabeth-line', 'overground'];
+  private readonly apiUrl = `https://api.tfl.gov.uk/Line/Mode/${this.MODES.join(',')}/Status`;
+
+  protected lineConfigs: LineConfig[] = [
+    { index: 0, name: "Bakerloo", color: 0xB36305, striped: false },
+    { index: 1, name: "Central", color: 0xE32017, striped: false },
+    { index: 2, name: "Circle", color: 0xFFD300, striped: false },
+    { index: 3, name: "District", color: 0x00782A, striped: false },
+    { index: 4, name: "DLR", color: 0x00AFAD, striped: true },
+    { index: 5, name: "Elizabeth", color: 0x9364CD, striped: true },
+    { index: 6, name: "Hammersmith & City", color: 0xF3A9BB, striped: false },
+    { index: 7, name: "Jubilee", color: 0xA0A5A9, striped: false },
+    { index: 8, name: "Liberty", color: 0x686868, striped: true },
+    { index: 9, name: "Lioness", color: 0xFEAF3F, striped: true },
+    { index: 10, name: "Metropolitan", color: 0x9B0056, striped: false },
+    { index: 11, name: "Mildmay", color: 0x0055FF, striped: true },
+    { index: 12, name: "Northern", color: 0x000000, striped: false },
+    { index: 13, name: "Piccadilly", color: 0x003688, striped: false },
+    { index: 14, name: "Suffragette", color: 0x55FF00, striped: true },
+    { index: 15, name: "Victoria", color: 0x0098D4, striped: false },
+    { index: 16, name: "Waterloo & City", color: 0x95CDBA, striped: false },
+    { index: 17, name: "Weaver", color: 0xA12860, striped: true },
+    { index: 18, name: "Windrush", color: 0xE32017, striped: true },
+  ];
+
+  protected lineIdToIndex: { [key: string]: number } = {
+    'bakerloo': 0,
+    'central': 1,
+    'circle': 2,
+    'district': 3,
+    'dlr': 4,
+    'elizabeth': 5,
+    'hammersmith-city': 6,
+    'jubilee': 7,
+    'liberty': 8,
+    'lioness': 9,
+    'metropolitan': 10,
+    'mildmay': 11,
+    'northern': 12,
+    'piccadilly': 13,
+    'suffragette': 14,
+    'victoria': 15,
+    'waterloo-city': 16,
+    'weaver': 17,
+    'windrush': 18,
+  };
+
+  /**
+   * Map TfL severity codes to StatusSeverity enum
+   * TfL severity codes:
+   * 20 - No Service
+   * 19 - Information
+   * 18 - No Issues
+   * 17 - Issues Reported
+   * 16 - Not Running
+   * 15 - Diverted
+   * 14 - Change of Frequency
+   * 13 - No Step Free Access
+   * 12 - Exit Only
+   * 11 = Part Closed
+   * 10 = Good Service
+   * 9 = Minor Delays
+   * 6 = Severe Delays
+   * 5 = Part Closure
+   * 4 = Planned Closure
+   * 3 = Part Suspended
+   * 2 = Suspended
+   * 1 = Closed
+   * 0 = Suspended
+   */
+  protected mapSeverity(severityCode: number): StatusSeverity {
+    switch (severityCode) {
+      case 18:
+      case 10:
+        return StatusSeverity.Good;
+      case 17:
+      case 14:
+      case 13:
+      case 12:
+      case 11:
+      case 9:
+      case 5:
+        return StatusSeverity.Warning;
+      case 20:
+      case 19:
+      case 16:
+      case 15:
+      case 6:
+      case 4:
+      case 3:
+      case 2:
+      case 1:
+      case 0:
+        return StatusSeverity.Severe;
+      default:
+        return StatusSeverity.Warning;
+    }
+  }
+
+  /**
+   * Fetch current line statuses from TfL API
+   */
+  async fetchLines(): Promise<LineStatus[] & { configMapping: number[] }> {
+    try {
+      const data = await PebbleTS.fetchJSON<TfLApiResult[]>(this.apiUrl);
+
+      if (!data || !Array.isArray(data)) {
+        console.warn('No valid data from TfL API');
+        return this.emptyResult();
+      }
+
+      const filtered = data
+        .filter((line: TfLApiResult) => {
+          return line.lineStatuses &&
+            line.lineStatuses.length > 0
+        })
+        .map((line: TfLApiResult): LineStatus | null => {
+          const lineIndex = this.lineIdToIndex[line.id];
+          if (lineIndex === undefined) {
+            return null; // Skip unknown lines
+          }
+
+          const status = line.lineStatuses[0];
+          return {
+            index: lineIndex,
+            status: status.statusSeverityDescription || 'Unknown',
+            severity: this.mapSeverity(status.statusSeverity),
+            reason: status.reason || '',
+          };
+        })
+        .filter((line): line is LineStatus => line !== null)
+        .filter((line: LineStatus) => line.severity !== StatusSeverity.Good);
+
+      const result = filtered as LineStatus[] & { configMapping: number[] };
+      result.configMapping = filtered.map(line => line.index);
+      return result;
+    } catch (error) {
+      console.log(`Error fetching London lines: ${error}`);
+      return this.emptyResult();
+    }
+  }
+
+  /**
+   * Create empty result with configMapping
+   */
+  private emptyResult(): LineStatus[] & { configMapping: number[] } {
+    const empty = [] as unknown as LineStatus[] & { configMapping: number[] };
+    empty.configMapping = [];
+    return empty;
+  }
+}
+
+/**
+ * Export singleton instance
+ */
+export const londonUndergroundBackend = new LondonUndergroundBackend();

--- a/watchapps/tube-status/src/ts/backends/type.ts
+++ b/watchapps/tube-status/src/ts/backends/type.ts
@@ -1,0 +1,57 @@
+const MAX_REASON_LENGTH = 512;
+
+/**
+ * Status severity levels
+ */
+export enum StatusSeverity {
+  Good = 0,
+  Warning = 1,
+  Severe = 2
+}
+
+/**
+ * Line configuration
+ */
+export type LineConfig = {
+  index: number;
+  name: string;
+  color: number;      // Hex color as uint32
+  striped: boolean;   // Renders a visual difference, can be used to indicate special lines
+};
+
+/**
+ * Line status data
+ */
+export type LineStatus = {
+  index: number;
+  status: string;
+  severity: StatusSeverity;
+  reason: string;
+};
+
+/**
+ * Base abstract class for transit backends
+ */
+export abstract class TransitBackend {
+  abstract readonly id: string;
+  abstract readonly name: string;
+
+  protected abstract lineConfigs: LineConfig[];
+  protected abstract lineIdToIndex: { [key: string]: number };
+
+
+  getLineConfigs(): LineConfig[] {
+    return this.lineConfigs;
+  }
+
+  abstract fetchLines(): Promise<LineStatus[] & { configMapping: number[] }>;
+
+  protected abstract mapSeverity(input: string | number): StatusSeverity;
+
+  protected truncateReason(reason: string): string {
+    if (reason.length > MAX_REASON_LENGTH) {
+      return reason.substring(0, MAX_REASON_LENGTH - 4) + '...';
+    }
+    return reason;
+  }
+}


### PR DESCRIPTION
We've discussed this briefly in private but I wanted to raise this as a reivew-able for if you're interested with no timeline or pressure to merge back at all.

For my own purposes to make Tube Status work for JR East Kanto, I've gone through a few iterations of design to get the London Underground information off of the watch so it can just take any data from the phone and present it the same way it does exactly today.

The goals here are:
1. **Touch as little as possible**. I tried to not rework anything other than what needed to be done minimally without also causing poor patterns to develop. In this, I ended up changing how the data is populated, but kept the interface in tact for the UI to access
2. **Maintain existing platform compatbility.** Some lines may require more than 25 alerts at once, but London Underground, at 18-19 lines, probably won't
3. **Maintain existing behavior to production Tube Status app.** There were a couple spots where I added some warning/severe mappings for statuses that weren't clear if you were covering or not, but I think it's documented well enough to discuss
4. **Define a clear path forward for additional transit systems**. I have a working JR East Kanto and NYC MTA Subway backend on my local machine using this exact same API that London is using. I am using an abstract class that, as long as fully implemented, will work. This gives each system the flexibility to resolve the data internally however it needs for the class to produce. Some logic, such as the mapping of statuses to configuration, are included for London even though they aren't needed, as some systems may return status and configuration on different APIs to be reconciled later (NYC MTA does this)
6. **Make all Tube Status concepts abstract without removing anything**. I've preserved everything that Tube Status already does which is mostly generic. However some things I did not understand how you used them. For example "striped" is something that is a visual piece for lines that I don't understand. I kept it though because regardless of why it is used by you for London Underground, anything else can use it to signify something else. For example I use it for the major lines in JR East Kanto to help separate the city main lines from the local/thru lines.
7. **Make adding new transit systems as non-invasive as possible**. I have 4 other transit system I'm interested (2 done, 2 in the works) that are just 4 files on my machine and no other changes. What is in this PR is the entirety of what would allow other backends to work.

Changes:
- The watch code has no concept of specific lines. It now just sets a max of 25 and all the properties that a line needs (name, color, status, severity code, description, striped)
- The phone sends two batches to the watch, the configuration data and the status information. It will only configure lines that actually have statuses to present so even if a transit system has 50 lines, it'll only overflow the 25 line limit if there are more than 25 active status issues
- The backend for London Underground is abstracted away to conform to the generic TransitBackend class
- Severity status for London uses the code rather than the description. I think I mapped them the same as you had still

Again I don't need you to merge this or not. I am going to continue working on it as my own project to be able to switch between transit systems that I feel are useful to me. But if it feels sufficient to you or when you have time discuss it, I think even if you never decide to support more systems than London in the Tube Status app, this at least sets up an easier system to work with overall even just for London.

London Underground:
<img width="144" height="168" alt="pebble_screenshot_2025-12-17_21-09-11" src="https://github.com/user-attachments/assets/ccb98c23-7329-4043-84be-839ed260158b" />

JR East Kanto:
<img width="144" height="168" alt="pebble_screenshot_2025-12-17_21-08-56" src="https://github.com/user-attachments/assets/775a7c97-e1ba-48e5-abcd-35ab6a873254" />

NYC MTA Subways:
<img width="144" height="168" alt="pebble_screenshot_2025-12-17_21-09-37" src="https://github.com/user-attachments/assets/618993cf-b4f4-40dc-9535-7d83644aa054" />

