### PR TITLE
[WIP] Create a Generic "Transit Status" application inside of Tube Status project

### DIFF
--- a/watchapps/tube-status/package-lock.json
+++ b/watchapps/tube-status/package-lock.json
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/watchapps/tube-status/package-transit_status.json
+++ b/watchapps/tube-status/package-transit_status.json
@@ -1,0 +1,7 @@
+{
+  "name": "transit-status",
+  "pebble": {
+    "uuid": "19704840-b25d-487c-9f6f-e4ea0d6a832c",
+    "displayName": "Transit Status"
+  }
+}

--- a/watchapps/tube-status/package-transit_status.json
+++ b/watchapps/tube-status/package-transit_status.json
@@ -1,5 +1,6 @@
 {
   "name": "transit-status",
+  "version": "3.13.0",
   "pebble": {
     "uuid": "19704840-b25d-487c-9f6f-e4ea0d6a832c",
     "displayName": "Transit Status"

--- a/watchapps/tube-status/package.json
+++ b/watchapps/tube-status/package.json
@@ -49,7 +49,7 @@
       "LineStatusSeverity"
     ],
     "enableMultiJS": true,
-    "displayName": "Tube Status",
+    "displayName": "Transit Status",
     "watchapp": {
       "onlyShownOnCommunication": false,
       "hiddenApp": false,

--- a/watchapps/tube-status/package.json
+++ b/watchapps/tube-status/package.json
@@ -37,7 +37,11 @@
     "projectType": "native",
     "uuid": "5120531c-9d73-4852-b26d-3d3cee90d92a",
     "messageKeys": [
-      "FlagJSReady",
+      "Type",
+      "RequestAvailableTransitSystems",
+      "AvailableTransitSystemName",
+      "AvailableTransitSystemRegion",
+      "AvailableTransitSystemIndex",
       "RequestTransitSystem",
       "LineStatusIndex",
       "LineStatus",

--- a/watchapps/tube-status/package.json
+++ b/watchapps/tube-status/package.json
@@ -37,12 +37,16 @@
     "projectType": "native",
     "uuid": "5120531c-9d73-4852-b26d-3d3cee90d92a",
     "messageKeys": [
-      "LineIndex",
-      "LineType",
+      "LineStatusIndex",
       "LineStatus",
       "LineReason",
       "FlagIsComplete",
-      "FlagLineCount"
+      "FlagLineCount",
+      "ConfigLineIndex",
+      "ConfigLineName",
+      "ConfigLineColor",
+      "ConfigLineStriped",
+      "LineStatusSeverity"
     ],
     "enableMultiJS": true,
     "displayName": "Tube Status",

--- a/watchapps/tube-status/package.json
+++ b/watchapps/tube-status/package.json
@@ -37,6 +37,8 @@
     "projectType": "native",
     "uuid": "5120531c-9d73-4852-b26d-3d3cee90d92a",
     "messageKeys": [
+      "FlagJSReady",
+      "RequestTransitSystem",
       "LineStatusIndex",
       "LineStatus",
       "LineReason",
@@ -49,7 +51,7 @@
       "LineStatusSeverity"
     ],
     "enableMultiJS": true,
-    "displayName": "Transit Status",
+    "displayName": "Tube Status",
     "watchapp": {
       "onlyShownOnCommunication": false,
       "hiddenApp": false,

--- a/watchapps/tube-status/src/c/config.h
+++ b/watchapps/tube-status/src/c/config.h
@@ -2,6 +2,14 @@
 
 #include <pebble.h>
 
+#if defined(APP_VARIANT_TUBE_STATUS)
+// Tube Status does not use the transit system selection feature so no slots needed
+#define MAX_TRANSIT_SYSTEMS 0
+#else
+// This should be equal to the known number of transit system backends on the phone side JS
+#define MAX_TRANSIT_SYSTEMS 3
+#endif
+
 // Aplite should not go over 25 lines, add a condition we if add a transit system that would ever have more than 25
 // outages at once. 
 // If regular/nightly service closures exceed this amount for a line, they may need filtered out in the backend.

--- a/watchapps/tube-status/src/c/config.h
+++ b/watchapps/tube-status/src/c/config.h
@@ -2,27 +2,14 @@
 
 #include <pebble.h>
 
-// Order is very important - must match JS side
-typedef enum {
-  LineTypeBakerloo = 0,
-  LineTypeCentral,
-  LineTypeCircle,
-  LineTypeDistrict,
-  LineTypeDLR,
-  LineTypeElizabeth,
-  LineTypeHammersmithAndCity,
-  LineTypeJubilee,
-  LineTypeLiberty,
-  LineTypeLioness,
-  LineTypeMetropolitan,
-  LineTypeMildmay,
-  LineTypeNorthern,
-  LineTypePicadilly,
-  LineTypeSuffragette,
-  LineTypeVictoria,
-  LineTypeWaterlooAndCity,
-  LineTypeWeaver,
-  LineTypeWindrush,
+// Aplite should not go over 25 lines, add a condition we if add a transit system that would ever have more than 25
+// outages at once. 
+// If regular/nightly service closures exceed this amount for a line, they may need filtered out in the backend.
+#define MAX_LINES 25
 
-  LineTypeMax
-} LineType;
+// Status severity levels for visual indication
+typedef enum {
+  StatusSeverityGood = 0,
+  StatusSeverityWarning = 1,
+  StatusSeveritySevere = 2
+} StatusSeverity;

--- a/watchapps/tube-status/src/c/modules/comm.c
+++ b/watchapps/tube-status/src/c/modules/comm.c
@@ -6,57 +6,102 @@ void set_fast(bool fast) {
   app_comm_set_sniff_interval(fast ? SNIFF_INTERVAL_REDUCED: SNIFF_INTERVAL_NORMAL);
 }
 
+void request_default_transit_system() {
+  comm_request_transit_system(-1);
+}
+
 static void inbox_received_handler(DictionaryIterator *iter, void *context) {
   // APP_LOG(APP_LOG_LEVEL_DEBUG, "Size: %d", packet_get_size(iter));
 
-  // Handle incoming line configuration data
-  if (packet_contains_key(iter, MESSAGE_KEY_ConfigLineIndex)) {
-    int index = packet_get_integer(iter, MESSAGE_KEY_ConfigLineIndex);
-    char *name = packet_get_string(iter, MESSAGE_KEY_ConfigLineName);
-    uint32_t color = (uint32_t)packet_get_integer(iter, MESSAGE_KEY_ConfigLineColor);
-    bool striped = packet_get_integer(iter, MESSAGE_KEY_ConfigLineStriped) != 0;
+  if (packet_contains_key(iter, MESSAGE_KEY_Type)) {
+    char *type = packet_get_string(iter, MESSAGE_KEY_Type);
 
-    data_set_line_config(index, name, color, striped);
-    APP_LOG(APP_LOG_LEVEL_DEBUG, "Configured line %d: %s", index, name);
-    data_set_progress(data_get_progress() + 1);
-    splash_window_update();
-    return;
-  }
+    if (strcmp(type, "ready") == 0) {
+#if defined(APP_VARIANT_TUBE_STATUS)
+      request_default_transit_system();
+#else
+      DictionaryIterator *out_iter;
+      AppMessageResult result = app_message_outbox_begin(&out_iter);
+      if (result == APP_MSG_OK) {
+        dict_write_int8(out_iter, MESSAGE_KEY_RequestAvailableTransitSystems, 1);
+        app_message_outbox_send();
+        APP_LOG(APP_LOG_LEVEL_DEBUG, "Requested available transit systems");
+      } else {
+        APP_LOG(APP_LOG_LEVEL_ERROR, "Failed to begin outbox: %d", result);
+      }
+      return;
+#endif
+    } else if (strcmp(type, "lineConfig") == 0) {
+      if (packet_contains_key(iter, MESSAGE_KEY_ConfigLineIndex)) {
+        int index = packet_get_integer(iter, MESSAGE_KEY_ConfigLineIndex);
+        char *name = packet_get_string(iter, MESSAGE_KEY_ConfigLineName);
+        uint32_t color = (uint32_t)packet_get_integer(iter, MESSAGE_KEY_ConfigLineColor);
+        bool striped = packet_get_integer(iter, MESSAGE_KEY_ConfigLineStriped) != 0;
 
-  // Handle incoming line status data
-  if (packet_contains_key(iter, MESSAGE_KEY_LineStatusIndex)) {
-    int index = packet_get_integer(iter, MESSAGE_KEY_LineStatusIndex);
-    // APP_LOG(APP_LOG_LEVEL_DEBUG, "Index: %d", index);
+        data_set_line_config(index, name, color, striped);
+        APP_LOG(APP_LOG_LEVEL_DEBUG, "Configured line %d: %s", index, name);
+        data_set_progress(data_get_progress() + 1);
+        splash_window_update();
+        return;
+      }
+    } else if (strcmp(type, "lineStatus") == 0) {
+      if (packet_contains_key(iter, MESSAGE_KEY_LineStatusIndex)) {
+        int index = packet_get_integer(iter, MESSAGE_KEY_LineStatusIndex);
+        // APP_LOG(APP_LOG_LEVEL_DEBUG, "Index: %d", index);
 
-    LineData *line_data = data_get_line(index);
-    line_data->index = index;
+        LineData *line_data = data_get_line(index);
+        line_data->index = index;
 
-    char *status = packet_get_string(iter, MESSAGE_KEY_LineStatus);
-    snprintf(line_data->state, strlen(status) + 1 /* EOF */, "%s", status);
+        char *status = packet_get_string(iter, MESSAGE_KEY_LineStatus);
+        snprintf(line_data->state, strlen(status) + 1 /* EOF */, "%s", status);
 
-    char *reason = packet_get_string(iter, MESSAGE_KEY_LineReason);
-    snprintf(line_data->reason, strlen(reason) + 1 /* EOF */, "%s", reason);
+        char *reason = packet_get_string(iter, MESSAGE_KEY_LineReason);
+        snprintf(line_data->reason, strlen(reason) + 1 /* EOF */, "%s", reason);
 
-    if (packet_contains_key(iter, MESSAGE_KEY_LineStatusSeverity)) {
-      line_data->severity = (StatusSeverity)packet_get_integer(iter, MESSAGE_KEY_LineStatusSeverity);
+        if (packet_contains_key(iter, MESSAGE_KEY_LineStatusSeverity)) {
+          line_data->severity = (StatusSeverity)packet_get_integer(iter, MESSAGE_KEY_LineStatusSeverity);
+        } else {
+          line_data->severity = StatusSeverityGood;
+        }
+      }
+
+      if (
+        packet_contains_key(iter, MESSAGE_KEY_FlagIsComplete) &&
+        packet_get_integer(iter, MESSAGE_KEY_FlagIsComplete) == 1
+      ) {
+        set_fast(false);
+        line_window_push();
+      }
+    } else if (strcmp(type, "availableTransitSystem") == 0) {
+      if (packet_contains_key(iter, MESSAGE_KEY_AvailableTransitSystemName) &&
+        packet_contains_key(iter, MESSAGE_KEY_AvailableTransitSystemRegion) &&
+        packet_contains_key(iter, MESSAGE_KEY_AvailableTransitSystemIndex)) {
+        char *name = packet_get_string(iter, MESSAGE_KEY_AvailableTransitSystemName);
+        char *region = packet_get_string(iter, MESSAGE_KEY_AvailableTransitSystemRegion);
+        int index = packet_get_integer(iter, MESSAGE_KEY_AvailableTransitSystemIndex);
+
+        data_set_transit_system_data(index, name, region);
+
+        if (
+          packet_contains_key(iter, MESSAGE_KEY_FlagIsComplete) &&
+          packet_get_integer(iter, MESSAGE_KEY_FlagIsComplete) == 1
+        ) {
+          transit_system_selection_window_push();
+        } 
+      } else {
+        request_default_transit_system();
+      }
     } else {
-      line_data->severity = StatusSeverityGood;
+      APP_LOG(APP_LOG_LEVEL_WARNING, "Unknown message type: %s", type);
+      return;
     }
   }
 
-  // Update progress for any status or config message
+  // Update progress for any messaging
   data_set_progress(data_get_progress() + 1);
   if (packet_contains_key(iter, MESSAGE_KEY_FlagLineCount)) {
     data_set_progress_max(packet_get_integer(iter, MESSAGE_KEY_FlagLineCount) * 2);
     splash_window_update();
-  }
-
-  if (
-    packet_contains_key(iter, MESSAGE_KEY_FlagIsComplete) &&
-    packet_get_integer(iter, MESSAGE_KEY_FlagIsComplete) == 1
-  ) {
-    set_fast(false);
-    line_window_push();
   }
 }
 
@@ -79,4 +124,17 @@ void comm_deinit() {
     app_timer_cancel(s_timeout_timer);
     s_timeout_timer = NULL;
   }
+}
+
+void comm_request_transit_system(int index) {
+  DictionaryIterator *out_iter;
+  AppMessageResult result = app_message_outbox_begin(&out_iter);
+  if (result == APP_MSG_OK) {
+    dict_write_int8(out_iter, MESSAGE_KEY_RequestTransitSystem, index);
+    app_message_outbox_send();
+    APP_LOG(APP_LOG_LEVEL_DEBUG, "Requested transit system data for index %d", index);
+  } else {
+    APP_LOG(APP_LOG_LEVEL_ERROR, "Failed to begin outbox: %d", result);
+  }
+  return;
 }

--- a/watchapps/tube-status/src/c/modules/comm.h
+++ b/watchapps/tube-status/src/c/modules/comm.h
@@ -7,6 +7,9 @@
 
 #include "../config.h"
 #include "../windows/common/splash_window.h"
+#if defined(APP_VARIANT_TRANSIT_STATUS)
+#include "../windows/transit_status/transit_system_selection_window.h"
+#endif
 #include "../windows/rect/line_window.h"
 #include "../windows/round/line_window.h"
 #include "data.h"
@@ -17,3 +20,5 @@
 void comm_init();
 
 void comm_deinit();
+
+void comm_request_transit_system(int index);

--- a/watchapps/tube-status/src/c/modules/data.c
+++ b/watchapps/tube-status/src/c/modules/data.c
@@ -1,5 +1,6 @@
 #include "data.h"
 
+static TransitSystemData s_transit_system_data[MAX_TRANSIT_SYSTEMS];
 static LineConfig s_line_configs[MAX_LINES];
 static LineData s_line_data[MAX_LINES];
 static int s_progress = 0;
@@ -9,6 +10,31 @@ void data_init() {
 }
 
 void data_deinit() {
+}
+
+void data_set_transit_system_data(int index, const char *name, const char *region) {
+  if (index < 0 || index >= MAX_TRANSIT_SYSTEMS) {
+    return;
+  }
+
+  TransitSystemData *transit_system_data = &s_transit_system_data[index];
+  transit_system_data->index = index;
+  snprintf(transit_system_data->name, sizeof(transit_system_data->name), "%s", name);
+  snprintf(transit_system_data->region, sizeof(transit_system_data->region), "%s", region);
+}
+
+char *data_get_transit_system_name(int index) {
+  if (index < 0 || index >= MAX_TRANSIT_SYSTEMS) {
+    return "";
+  }
+  return s_transit_system_data[index].name;
+}
+
+char *data_get_transit_system_region(int index) {
+  if (index < 0 || index >= MAX_TRANSIT_SYSTEMS) {
+    return "";
+  }
+  return s_transit_system_data[index].region;
 }
 
 void data_set_line_config(int index, const char *name, uint32_t color, bool striped) {

--- a/watchapps/tube-status/src/c/modules/data.h
+++ b/watchapps/tube-status/src/c/modules/data.h
@@ -5,25 +5,34 @@
 #include "../config.h"
 
 typedef struct {
-  int index;  // Unused?
-  int type;
+  bool configured;
+  char name[32];
+  uint32_t color;
+  bool striped;
+} LineConfig;
+
+typedef struct {
+  int index;
   char state[32];
   char reason[512];
+  StatusSeverity severity;
 } LineData;
 
 void data_init();
 
 void data_deinit();
 
-char* data_get_line_name(int type);
+void data_set_line_config(int index, const char *name, uint32_t color, bool striped);
 
-LineData* data_get_line(int index);
+char *data_get_line_name(int index);
 
-GColor data_get_line_color(int type);
+LineData *data_get_line(int index);
+
+GColor data_get_line_color(int index);
 
 GColor data_get_line_state_color(int index);
 
-bool data_get_line_color_is_striped(int type);
+bool data_get_line_color_is_striped(int index);
 
 void data_set_progress(int progress);
 
@@ -36,3 +45,5 @@ bool data_get_line_has_reason(int index);
 int data_get_progress_max();
 
 int data_get_lines_received();
+
+int data_get_configured_line_count();

--- a/watchapps/tube-status/src/c/modules/data.h
+++ b/watchapps/tube-status/src/c/modules/data.h
@@ -5,6 +5,12 @@
 #include "../config.h"
 
 typedef struct {
+  int index;
+  char name[32];
+  char region[32];
+} TransitSystemData;
+
+typedef struct {
   bool configured;
   char name[32];
   uint32_t color;
@@ -21,6 +27,12 @@ typedef struct {
 void data_init();
 
 void data_deinit();
+
+void data_set_transit_system_data(int index, const char *name, const char *region);
+
+char *data_get_transit_system_name(int index);
+
+char *data_get_transit_system_region(int index);
 
 void data_set_line_config(int index, const char *name, uint32_t color, bool striped);
 

--- a/watchapps/tube-status/src/c/windows/rect/line_window.c
+++ b/watchapps/tube-status/src/c/windows/rect/line_window.c
@@ -20,7 +20,7 @@ static void select_click_handler(struct MenuLayer *menu_layer, MenuIndex *cell_i
 
 /********************************* MenuLayer **********************************/
 
-void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_index, void *context) {
+static void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_index, void *context) {
   GRect bounds = layer_get_bounds(cell_layer);
   int index = cell_index->row;
 
@@ -150,7 +150,7 @@ void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_in
   graphics_fill_rect(ctx, GRect(bounds.origin.x, bounds.size.h - sep_h, bounds.size.w, sep_h), GCornerNone, 0);
 }
 
-uint16_t get_num_rows_handler(MenuLayer *menu_layer, uint16_t section_index, void *context) {
+static uint16_t get_num_rows_handler(MenuLayer *menu_layer, uint16_t section_index, void *context) {
   // Number of concern sent by JS plus one for 'all others are good' notice
   return data_get_lines_received() + 1;
 }

--- a/watchapps/tube-status/src/c/windows/rect/line_window.c
+++ b/watchapps/tube-status/src/c/windows/rect/line_window.c
@@ -62,14 +62,14 @@ void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_in
 
   // Line color
   int line_color_x = center.x - (STRIPE_WIDTH / 2);
-  graphics_context_set_fill_color(ctx, data_get_line_color(line_data->type));
+  graphics_context_set_fill_color(ctx, data_get_line_color(line_data->index));
   graphics_fill_rect(
     ctx,
     GRect(line_color_x, bounds.origin.y, STRIPE_WIDTH, bounds.size.h),
     GCornerNone,
     0
   );
-  if (data_get_line_color_is_striped(line_data->type)) {
+  if (data_get_line_color_is_striped(line_data->index)) {
     graphics_context_set_fill_color(ctx, GColorWhite);
     graphics_fill_rect(
       ctx,
@@ -95,7 +95,7 @@ void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_in
   graphics_context_set_text_color(ctx, GColorBlack);
   graphics_draw_text(
     ctx,
-    data_get_line_name(line_data->type),
+    data_get_line_name(line_data->index),
     scalable_get_font(SFI_Medium),
     scalable_grect_pp(
       GRect(220, -40, 750, 200),
@@ -128,7 +128,7 @@ void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_in
       GCornerNone,
       0
     );
-    
+
     // Arrow
     graphics_draw_text(
       ctx,

--- a/watchapps/tube-status/src/c/windows/round/line_window.c
+++ b/watchapps/tube-status/src/c/windows/round/line_window.c
@@ -207,7 +207,7 @@ void line_window_push() {
   window_stack_push(s_window, true);
 
   // Begin with the first line
-  s_selected_line = LineTypeBakerloo;
+  s_selected_line = 0;
   layer_mark_dirty(s_ring_layer);
 }
 #endif

--- a/watchapps/tube-status/src/c/windows/transit_status/transit_system_selection_window.c
+++ b/watchapps/tube-status/src/c/windows/transit_status/transit_system_selection_window.c
@@ -1,0 +1,122 @@
+#if defined(APP_VARIANT_TRANSIT_STATUS)
+#include "transit_system_selection_window.h"
+
+static Window *s_window;
+static MenuLayer *s_menu_layer;
+static StatusBarLayer *s_status_bar;
+
+/******************************** Click config *********************************/
+static void select_click_handler(struct MenuLayer *menu_layer, MenuIndex *cell_index, void *context) {
+  int index = (int)cell_index->row;
+  data_set_progress(0); // Reset progress for new transit system load
+  comm_request_transit_system(index);
+  splash_window_push();
+}
+
+/********************************* MenuLayer **********************************/
+static void draw_row_handler(GContext *ctx, const Layer *cell_layer, MenuIndex *cell_index, void *context) {
+  GRect bounds = layer_get_bounds(cell_layer);
+  int index = cell_index->row;
+
+  graphics_context_set_fill_color(ctx, GColorWhite);
+  graphics_fill_rect(ctx, bounds, GCornerNone, 0);
+
+  graphics_context_set_text_color(ctx, GColorBlack);
+  graphics_draw_text(
+    ctx,
+    data_get_transit_system_region(index),
+    scalable_get_font(SFI_Medium),
+    scalable_grect_pp(
+      GRect(20, -40, 930, 200),
+      GRect(30, -20, 935, 200)
+    ),
+    GTextOverflowModeTrailingEllipsis,
+    GTextAlignmentLeft,
+    NULL
+  );
+  graphics_draw_text(
+    ctx,
+    data_get_transit_system_name(index),
+    scalable_get_font(SFI_MediumBold),
+    scalable_grect_pp(
+      GRect(20, 75, 930, 200),
+      GRect(30, 95, 935, 200)
+    ),
+    GTextOverflowModeTrailingEllipsis,
+    GTextAlignmentLeft,
+    NULL
+  );
+
+  if (menu_layer_is_index_selected(s_menu_layer, cell_index)) {
+    // Background
+    graphics_context_set_fill_color(ctx, data_get_line_state_color(cell_index->row));
+    graphics_fill_rect(
+      ctx,
+      scalable_grect(915, 0, 90, 260),
+      GCornerNone,
+      0
+    );
+
+    // Arrow
+    graphics_draw_text(
+      ctx,
+      ">",
+      scalable_get_font(SFI_MediumBold),
+      scalable_grect_pp(
+        GRect(930, 25, 120, 500),
+        GRect(935, 40, 120, 500)
+      ),
+      GTextOverflowModeWordWrap,
+      GTextAlignmentLeft,
+      NULL
+    );
+  }
+}
+
+static uint16_t get_num_rows_handler(MenuLayer *menu_layer, uint16_t section_index, void *context) {
+  return MAX_TRANSIT_SYSTEMS;
+}
+
+static void window_load(Window *window) {
+  Layer *window_layer = window_get_root_layer(s_window);
+  GRect bounds = layer_get_bounds(window_layer);
+
+  GEdgeInsets menu_insets = (GEdgeInsets) { .top = STATUS_BAR_LAYER_HEIGHT - 1 };
+  GRect menu_bounds = grect_inset(bounds, menu_insets);
+
+  s_status_bar = status_bar_layer_create();
+  status_bar_layer_set_separator_mode(s_status_bar, StatusBarLayerSeparatorModeDotted);
+  status_bar_layer_set_colors(s_status_bar, GColorWhite, GColorBlack);
+  layer_add_child(window_layer, status_bar_layer_get_layer(s_status_bar));
+
+  s_menu_layer = menu_layer_create(menu_bounds);
+  menu_layer_set_click_config_onto_window(s_menu_layer, s_window);
+  menu_layer_pad_bottom_enable(s_menu_layer, false);
+  menu_layer_set_callbacks(s_menu_layer, NULL, (MenuLayerCallbacks) {
+    .draw_row = draw_row_handler,
+    .get_num_rows = get_num_rows_handler,
+    .select_click = select_click_handler,
+  });
+  layer_add_child(window_layer, menu_layer_get_layer(s_menu_layer));
+}
+
+static void window_unload(Window *window) {
+  menu_layer_destroy(s_menu_layer);
+  status_bar_layer_destroy(s_status_bar);
+
+  window_destroy(s_window);
+  s_window = NULL;
+  window_stack_pop_all(true);  // Don't show splash on exit
+}
+
+void transit_system_selection_window_push() {
+  if (!s_window) {
+    s_window = window_create();
+    window_set_window_handlers(s_window, (WindowHandlers) {
+      .load = window_load,
+      .unload = window_unload,
+    });
+  }
+  window_stack_push(s_window, true);
+}
+#endif

--- a/watchapps/tube-status/src/c/windows/transit_status/transit_system_selection_window.h
+++ b/watchapps/tube-status/src/c/windows/transit_status/transit_system_selection_window.h
@@ -1,0 +1,10 @@
+#if defined(APP_VARIANT_TRANSIT_STATUS)
+#pragma once
+
+#include <pebble.h>
+#include "../../config.h"
+#include "../../modules/data.h"
+#include "../../modules/comm.h"
+
+void transit_system_selection_window_push();
+#endif

--- a/watchapps/tube-status/src/ts/backends/index.ts
+++ b/watchapps/tube-status/src/ts/backends/index.ts
@@ -1,0 +1,3 @@
+export { londonUndergroundBackend } from './londonunderground';
+export type { TransitBackend, LineConfig, LineStatus as GenericLineData } from './type';
+export { StatusSeverity } from './type';

--- a/watchapps/tube-status/src/ts/backends/index.ts
+++ b/watchapps/tube-status/src/ts/backends/index.ts
@@ -1,3 +1,4 @@
+export { jrEastKantoBackend } from './jreastkanto';
 export { londonUndergroundBackend } from './londonunderground';
 export type { TransitBackend, LineConfig, LineStatus as GenericLineData } from './type';
 export { StatusSeverity } from './type';

--- a/watchapps/tube-status/src/ts/backends/index.ts
+++ b/watchapps/tube-status/src/ts/backends/index.ts
@@ -1,4 +1,5 @@
 export { jrEastKantoBackend } from './jreastkanto';
 export { londonUndergroundBackend } from './londonunderground';
+export { nycMtaSubwayBackend } from './nycmtasubway';
 export type { TransitBackend, LineConfig, LineStatus as GenericLineData } from './type';
 export { StatusSeverity } from './type';

--- a/watchapps/tube-status/src/ts/backends/jreastkanto.ts
+++ b/watchapps/tube-status/src/ts/backends/jreastkanto.ts
@@ -10,7 +10,8 @@ interface SimpleLineStatus {
  */
 class JrEastKantoBackend extends TransitBackend {
     readonly id = 'jreastkanto';
-    readonly name = 'JR East Kanto';
+    readonly name = 'JR East';
+    readonly region = 'Kanto, Japan';
 
     private readonly baseUrl = 'https://traininfo.jreast.co.jp/train_info';
 

--- a/watchapps/tube-status/src/ts/backends/jreastkanto.ts
+++ b/watchapps/tube-status/src/ts/backends/jreastkanto.ts
@@ -1,0 +1,285 @@
+import { TransitBackend, LineConfig, LineStatus, StatusSeverity } from './type';
+
+interface SimpleLineStatus {
+    statusType: string;
+    reason?: string;
+}
+
+/**
+ * JR East Kanto transit backend
+ */
+class JrEastKantoBackend extends TransitBackend {
+    readonly id = 'jreastkanto';
+    readonly name = 'JR East Kanto';
+
+    private readonly baseUrl = 'https://traininfo.jreast.co.jp/train_info';
+
+    protected lineConfigs: LineConfig[] = [
+        { index: 0, name: "Yamanote", color: 0x92BE44, striped: true },
+        { index: 1, name: "Ueno-Tokyo", color: 0x306FBF, striped: false },
+        { index: 2, name: "Shonan-Shinjuku", color: 0xE02E3C, striped: true },
+        { index: 3, name: "Sotetsu", color: 0x306FBF, striped: false },
+        { index: 4, name: "Tokaido", color: 0xF19D56, striped: true },
+        { index: 5, name: "Keihin-Tohoku", color: 0x4AA4DE, striped: true },
+        { index: 6, name: "Yokosuka", color: 0x3172B8, striped: true },
+        { index: 7, name: "Nambu", color: 0xFBE54D, striped: true },
+        { index: 8, name: "Yokohama", color: 0x92BE44, striped: true },
+        { index: 9, name: "Ito", color: 0x4D8448, striped: false },
+        { index: 10, name: "Sagami", color: 0x3A8488, striped: false },
+        { index: 11, name: "Tsurumi", color: 0xFBE64D, striped: true },
+        { index: 12, name: "Utsunomiya", color: 0xF19D56, striped: true },
+        { index: 13, name: "Takasaki", color: 0xF19D56, striped: true },
+        { index: 14, name: "Saikyo", color: 0x4DA986, striped: true },
+        { index: 15, name: "Kawagoe", color: 0xA7A9AB, striped: false },
+        { index: 16, name: "Musashino", color: 0xDA6529, striped: true },
+        { index: 17, name: "Joetsu", color: 0x4DA9CD, striped: false },
+        { index: 18, name: "Shin-Etsu", color: 0x85BF41, striped: false },
+        { index: 19, name: "Agatsuma", color: 0x3A8488, striped: false },
+        { index: 20, name: "Karasuyama", color: 0xEF8D3C, striped: false },
+        { index: 21, name: "Hachiko", color: 0x9F9D96, striped: false },
+        { index: 22, name: "Nikko", color: 0xEF8D3C, striped: false },
+        { index: 23, name: "Ryomo", color: 0xF7D849, striped: false },
+        { index: 24, name: "Chuo Rapid", color: 0xDA6529, striped: true },
+        { index: 25, name: "Chuo-Sobu Local", color: 0xFBE64D, striped: true },
+        { index: 26, name: "Chuo", color: 0x306FBF, striped: false },
+        { index: 27, name: "Itsukaichi", color: 0xDA6529, striped: true },
+        { index: 28, name: "Ome", color: 0xDA6529, striped: true },
+        { index: 29, name: "Koumi", color: 0x4D8448, striped: false },
+        { index: 30, name: "Joban", color: 0x306FBF, striped: false },
+        { index: 31, name: "Joban Rapid", color: 0x57BE8E, striped: true },
+        { index: 32, name: "Joban Local", color: 0x9E9E9F, striped: true },
+        { index: 33, name: "Suigun", color: 0x4D8448, striped: false },
+        { index: 34, name: "Mito", color: 0x306FBF, striped: false },
+        { index: 35, name: "Sobu Rapid", color: 0x3172B8, striped: true },
+        { index: 36, name: "Sobu", color: 0xF7D849, striped: false },
+        { index: 37, name: "Keiyo", color: 0xBE2D2F, striped: true },
+        { index: 38, name: "Uchibo", color: 0x306FBF, striped: false },
+        { index: 39, name: "Kashima", color: 0x9E6327, striped: false },
+        { index: 40, name: "Kururi", color: 0x58C0A8, striped: false },
+        { index: 41, name: "Sotobo", color: 0xDE3C3E, striped: false },
+        { index: 42, name: "Togane", color: 0xA42D36, striped: false },
+        { index: 43, name: "Narita", color: 0x54B889, striped: false },
+        { index: 44, name: "Monorail", color: 0x133581, striped: true },
+    ];
+
+    protected lineIdToIndex: { [key: string]: number } = {
+        'yamanoteline': 0,
+        'ueno-tokyoline': 1,
+        'shonan-shinjukuline': 2,
+        'sotetsuline': 3,
+        'tokaidoline': 4,
+        'keihin-tohokuline': 5,
+        'yokosukaline': 6,
+        'nambuline': 7,
+        'yokohamaline': 8,
+        'itoline': 9,
+        'sagamiline': 10,
+        'tsurumiline': 11,
+        'utsunomiyaline': 12,
+        'takasakiline': 13,
+        'saikyoline': 14,
+        'kawagoeline': 15,
+        'musashinoline': 16,
+        'joetsuline': 17,
+        'shin-etsuline_kanto': 18,
+        'agatsumaline': 19,
+        'karasuyamaline': 20,
+        'hachikoline': 21,
+        'nikkoline': 22,
+        'ryomoline': 23,
+        'chuoline_rapidservice': 24,
+        'chuo_sobuline_local': 25,
+        'chuoline': 26,
+        'itsukaichiline': 27,
+        'omeline': 28,
+        'koumiline': 29,
+        'jobanline': 30,
+        'jobanline_rapidservice': 31,
+        'jobanline_local': 32,
+        'suigunline': 33,
+        'mitoline': 34,
+        'sobuline_rapidservice': 35,
+        'sobuline': 36,
+        'keiyoline': 37,
+        'uchiboline': 38,
+        'kashimaline': 39,
+        'kururiline': 40,
+        'sotoboline': 41,
+        'toganeline': 42,
+        'naritaline': 43,
+        'monorail': 44,
+    };
+
+    /**
+     * Map JR East status strings to StatusSeverity
+     */
+    protected mapSeverity(status: string): StatusSeverity {
+        if (status.includes('Delays') || status.includes('Notice')) {
+            return StatusSeverity.Warning;
+        }
+        if (status.includes('Disruptions')) {
+            return StatusSeverity.Severe;
+        }
+        return StatusSeverity.Good;
+    }
+
+    /**
+     * Extracts the line status containers from HTML
+     */
+    private extractLines(html: string): string[] {
+        const parentContainerRegex = /<div class="rosenBox">[\s\S]*?<div class="rosen_infoBox">[\s\S]*?<\/div>\s*<\/div>/g;
+        return html.match(parentContainerRegex) || [];
+    }
+
+    /**
+     * Parse status and reason for a single line
+     */
+    private parseSimpleLineStatus(boxContent: string): SimpleLineStatus | null {
+        const statusMatch = boxContent.match(/<div class="status (normal|delay|info|adjust)">/);
+        if (!statusMatch) return null;
+
+        const statusType = statusMatch[1];
+        const statusTextMatch = boxContent.match(/<p class="status_Text">(.*?)<\/p>/);
+        const reason = statusTextMatch ? statusTextMatch[1] : undefined;
+
+        return { statusType, reason };
+    }
+
+    /**
+     * Map status type to status description
+     */
+    private getStatusDescription(statusType: string): string {
+        const statusMap: { [key: string]: string } = {
+            normal: 'Good Service',
+            delay: 'Delays',
+            info: 'Notice',
+            adjust: 'Disruptions',
+        };
+        return statusMap[statusType] || statusType;
+    }
+
+    /**
+     * Build mapping of line IDs to their statuses from HTML
+     */
+    private buildLineIdStatusMap(pageHtml: string, extractLineId: boolean = true): Array<{ lineId: string; status: SimpleLineStatus } | null> {
+        const boxes = this.extractLines(pageHtml);
+        return boxes.map((boxContent) => {
+            let lineId: string | null = null;
+
+            if (extractLineId) {
+                const lineIdMatch = boxContent.match(/lineid=([^"&<>]+)/);
+                if (!lineIdMatch) return null;
+                lineId = lineIdMatch[1];
+            }
+
+            const status = this.parseSimpleLineStatus(boxContent);
+            if (!status) return null;
+
+            return { lineId: lineId!, status };
+        });
+    }
+
+    /**
+     * Parse train line data from HTML
+     * Extracts boxes from both Japanese and English, maintaining index alignment
+     */
+    private parseLineData(...args: { mode: string, html: string }[]): Array<LineStatus & { configIndex: number }> {
+        const jpHtml = args.find(arg => arg.mode === '')?.html || '';
+        const enHtml = args.find(arg => arg.mode === 'e')?.html || '';
+
+        // Parse both languages' boxes
+        const jpBoxes = this.buildLineIdStatusMap(jpHtml, true);
+        const enBoxes = this.buildLineIdStatusMap(enHtml, false);
+
+        if (jpBoxes.length !== enBoxes.length) {
+            console.warn(`Box count mismatch: ${jpBoxes.length} JP boxes, ${enBoxes.length} EN boxes, returning only JP data.`);
+            return jpBoxes
+                .filter(Boolean)
+                .map((box, i) => {
+                    if (!box?.lineId) return null;
+                    const configIndex = this.lineIdToIndex[box.lineId];
+                    if (configIndex === undefined) return null;
+
+                    const status = this.getStatusDescription(box.status.statusType);
+                    return {
+                        index: i,
+                        configIndex,
+                        status,
+                        severity: this.mapSeverity(status),
+                        reason: this.truncateReason(box.status.reason || ''),
+                    };
+                })
+                .filter((line): line is NonNullable<typeof line> => line !== null);
+        }
+
+        const result: Array<LineStatus & { configIndex: number }> = [];
+
+        // Combine data ensuring line IDs from Japanese version are used
+        const maxLength = Math.max(jpBoxes.length, enBoxes.length);
+        for (let i = 0; i < maxLength; i++) {
+            const jpBox = jpBoxes[i];
+            const enBox = enBoxes[i];
+
+            // Skip if no Japanese box, as line IDs are essential
+            if (!jpBox) {
+                console.warn(`Skipping index ${i} due to missing Japanese box.`);
+                continue;
+            }
+
+            const configIndex = this.lineIdToIndex[jpBox.lineId];
+            if (configIndex === undefined) {
+                continue;
+            }
+
+            // Use English status and reason if available, fall back to Japanese
+            const statusType = enBox ? enBox.status.statusType : jpBox.status.statusType;
+            const status = this.getStatusDescription(statusType);
+            const reason = (enBox?.status.reason || jpBox.status.reason || '');
+
+            result.push({
+                index: result.length,
+                configIndex,
+                status,
+                severity: this.mapSeverity(status),
+                reason: this.truncateReason(reason),
+            });
+        }
+
+        return result;
+    }
+
+    /**
+     * Fetch current line statuses from JR East website
+     */
+    async fetchLines(): Promise<LineStatus[] & { configMapping: number[] }> {
+        // Fetch both Japanese and English pages
+        const [result1, result2] = await Promise.all(['', 'e'].map(async (mode) => ({
+            mode,
+            html: await PebbleTS.fetchString(`${this.baseUrl}/${mode}/kanto.aspx`)
+        })));
+
+        const linesWithIssues = this.parseLineData(result1, result2);
+
+        // Filter only lines with issues
+        const filtered = linesWithIssues.filter(line => line.status !== 'Good Service');
+
+        // Build result with sequential display indices
+        const result: Array<LineStatus & { configIndex?: number }> = filtered.map((line, i) => ({
+            index: i,
+            status: line.status,
+            severity: line.severity,
+            reason: line.reason,
+            configIndex: line.configIndex,
+        }));
+
+        // Add config mapping
+        const typedResult = result as LineStatus[] & { configMapping: number[] };
+        typedResult.configMapping = result.map(r => r.configIndex!);
+        return typedResult;
+    }
+}
+
+/**
+ * Export singleton instance
+ */
+export const jrEastKantoBackend = new JrEastKantoBackend();

--- a/watchapps/tube-status/src/ts/backends/londonunderground.ts
+++ b/watchapps/tube-status/src/ts/backends/londonunderground.ts
@@ -1,0 +1,175 @@
+import { TransitBackend, LineConfig, LineStatus, StatusSeverity } from './type';
+
+// API data type
+type TfLApiResult = {
+  id: string;
+  lineStatuses: {
+    statusSeverity: number;
+    statusSeverityDescription: string;
+    reason?: string;
+  }[];
+};
+
+/**
+ * London Underground / TfL transit backend
+ */
+class LondonUndergroundBackend extends TransitBackend {
+  readonly id = 'tfl';
+  readonly name = 'London Underground';
+
+  private readonly MODES = ['tube', 'dlr', 'elizabeth-line', 'overground'];
+  private readonly apiUrl = `https://api.tfl.gov.uk/Line/Mode/${this.MODES.join(',')}/Status`;
+
+  protected lineConfigs: LineConfig[] = [
+    { index: 0, name: "Bakerloo", color: 0xB36305, striped: false },
+    { index: 1, name: "Central", color: 0xE32017, striped: false },
+    { index: 2, name: "Circle", color: 0xFFD300, striped: false },
+    { index: 3, name: "District", color: 0x00782A, striped: false },
+    { index: 4, name: "DLR", color: 0x00AFAD, striped: true },
+    { index: 5, name: "Elizabeth", color: 0x9364CD, striped: true },
+    { index: 6, name: "Hammersmith & City", color: 0xF3A9BB, striped: false },
+    { index: 7, name: "Jubilee", color: 0xA0A5A9, striped: false },
+    { index: 8, name: "Liberty", color: 0x686868, striped: true },
+    { index: 9, name: "Lioness", color: 0xFEAF3F, striped: true },
+    { index: 10, name: "Metropolitan", color: 0x9B0056, striped: false },
+    { index: 11, name: "Mildmay", color: 0x0055FF, striped: true },
+    { index: 12, name: "Northern", color: 0x000000, striped: false },
+    { index: 13, name: "Piccadilly", color: 0x003688, striped: false },
+    { index: 14, name: "Suffragette", color: 0x55FF00, striped: true },
+    { index: 15, name: "Victoria", color: 0x0098D4, striped: false },
+    { index: 16, name: "Waterloo & City", color: 0x95CDBA, striped: false },
+    { index: 17, name: "Weaver", color: 0xA12860, striped: true },
+    { index: 18, name: "Windrush", color: 0xE32017, striped: true },
+  ];
+
+  protected lineIdToIndex: { [key: string]: number } = {
+    'bakerloo': 0,
+    'central': 1,
+    'circle': 2,
+    'district': 3,
+    'dlr': 4,
+    'elizabeth': 5,
+    'hammersmith-city': 6,
+    'jubilee': 7,
+    'liberty': 8,
+    'lioness': 9,
+    'metropolitan': 10,
+    'mildmay': 11,
+    'northern': 12,
+    'piccadilly': 13,
+    'suffragette': 14,
+    'victoria': 15,
+    'waterloo-city': 16,
+    'weaver': 17,
+    'windrush': 18,
+  };
+
+  /**
+   * Map TfL severity codes to StatusSeverity enum
+   * TfL severity codes:
+   * 20 - No Service
+   * 19 - Information
+   * 18 - No Issues
+   * 17 - Issues Reported
+   * 16 - Not Running
+   * 15 - Diverted
+   * 14 - Change of Frequency
+   * 13 - No Step Free Access
+   * 12 - Exit Only
+   * 11 = Part Closed
+   * 10 = Good Service
+   * 9 = Minor Delays
+   * 6 = Severe Delays
+   * 5 = Part Closure
+   * 4 = Planned Closure
+   * 3 = Part Suspended
+   * 2 = Suspended
+   * 1 = Closed
+   * 0 = Suspended
+   */
+  protected mapSeverity(severityCode: number): StatusSeverity {
+    switch (severityCode) {
+      case 18:
+      case 10:
+        return StatusSeverity.Good;
+      case 17:
+      case 14:
+      case 13:
+      case 12:
+      case 11:
+      case 9:
+      case 5:
+        return StatusSeverity.Warning;
+      case 20:
+      case 19:
+      case 16:
+      case 15:
+      case 6:
+      case 4:
+      case 3:
+      case 2:
+      case 1:
+      case 0:
+        return StatusSeverity.Severe;
+      default:
+        return StatusSeverity.Warning;
+    }
+  }
+
+  /**
+   * Fetch current line statuses from TfL API
+   */
+  async fetchLines(): Promise<LineStatus[] & { configMapping: number[] }> {
+    try {
+      const data = await PebbleTS.fetchJSON<TfLApiResult[]>(this.apiUrl);
+
+      if (!data || !Array.isArray(data)) {
+        console.warn('No valid data from TfL API');
+        return this.emptyResult();
+      }
+
+      const filtered = data
+        .filter((line: TfLApiResult) => {
+          return line.lineStatuses &&
+            line.lineStatuses.length > 0
+        })
+        .map((line: TfLApiResult): LineStatus | null => {
+          const lineIndex = this.lineIdToIndex[line.id];
+          if (lineIndex === undefined) {
+            return null; // Skip unknown lines
+          }
+
+          const status = line.lineStatuses[0];
+          return {
+            index: lineIndex,
+            status: status.statusSeverityDescription || 'Unknown',
+            severity: this.mapSeverity(status.statusSeverity),
+            reason: status.reason || '',
+          };
+        })
+        .filter((line): line is LineStatus => line !== null)
+        .filter((line: LineStatus) => line.severity !== StatusSeverity.Good);
+
+      const result = filtered as LineStatus[] & { configMapping: number[] };
+      result.configMapping = filtered.map(line => line.index);
+      return result;
+    } catch (error) {
+      console.log(`Error fetching London lines: ${error}`);
+      return this.emptyResult();
+    }
+  }
+
+  /**
+   * Create empty result with configMapping
+   */
+  private emptyResult(): LineStatus[] & { configMapping: number[] } {
+    const empty = [] as unknown as LineStatus[] & { configMapping: number[] };
+    empty.configMapping = [];
+    return empty;
+  }
+}
+
+/**
+ * Export singleton instance
+ */
+export const londonUndergroundBackend = new LondonUndergroundBackend();

--- a/watchapps/tube-status/src/ts/backends/londonunderground.ts
+++ b/watchapps/tube-status/src/ts/backends/londonunderground.ts
@@ -15,7 +15,8 @@ type TfLApiResult = {
  */
 class LondonUndergroundBackend extends TransitBackend {
   readonly id = 'tfl';
-  readonly name = 'London Underground';
+  readonly name = 'TfL';
+  readonly region = 'London, UK';
 
   private readonly MODES = ['tube', 'dlr', 'elizabeth-line', 'overground'];
   private readonly apiUrl = `https://api.tfl.gov.uk/Line/Mode/${this.MODES.join(',')}/Status`;

--- a/watchapps/tube-status/src/ts/backends/nycmtasubway.ts
+++ b/watchapps/tube-status/src/ts/backends/nycmtasubway.ts
@@ -1,0 +1,238 @@
+import { TransitBackend, LineConfig, LineStatus, StatusSeverity } from './type';
+
+interface MTAAlertEntity {
+    alert?: {
+        active_period?: Array<{ start: number, end: number }>;
+        informed_entity?: Array<{ route_id?: string }>;
+        header_text?: {
+            translation?: Array<{ text: string }>;
+        };
+        'transit_realtime.mercury_alert'?: {
+            alert_type?: string;
+        };
+    };
+}
+
+interface RouteIssue {
+    type: string;
+    descriptions: string[];
+    severity: StatusSeverity;
+}
+
+/**
+ * NYC MTA Subway transit backend
+ */
+class NycMtaSubwayBackend extends TransitBackend {
+    readonly id = 'nyc';
+    readonly name = 'NYC MTA Subway';
+
+    private readonly apiUrl = 'https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts.json';
+
+    protected lineConfigs: LineConfig[] = [
+        // Broadway-Seventh Avenue Line
+        { index: 0, name: "1 Train", color: 0xEE352E, striped: false },
+        { index: 1, name: "2 Train", color: 0xEE352E, striped: false },
+        { index: 2, name: "3 Train", color: 0xEE352E, striped: false },
+        // Lexington Avenue Line
+        { index: 3, name: "4 Train", color: 0x00933C, striped: false },
+        { index: 4, name: "5 Train", color: 0x00933C, striped: false },
+        { index: 5, name: "6 Train", color: 0x00933C, striped: false },
+        { index: 6, name: "6X Train", color: 0x00933C, striped: false },
+        // Flushing Line
+        { index: 7, name: "7 Train", color: 0xB933AD, striped: false },
+        { index: 8, name: "7X Train", color: 0xB933AD, striped: false },
+        // Broadway Line
+        { index: 9, name: "N Train", color: 0xFCCC0A, striped: false },
+        { index: 10, name: "Q Train", color: 0xFCCC0A, striped: false },
+        { index: 11, name: "R Train", color: 0xFCCC0A, striped: false },
+        { index: 12, name: "W Train", color: 0xFCCC0A, striped: false },
+        // Sixth Avenue Line
+        { index: 13, name: "B Train", color: 0xFF6319, striped: false },
+        { index: 14, name: "D Train", color: 0xFF6319, striped: false },
+        { index: 15, name: "F Train", color: 0xFF6319, striped: false },
+        { index: 16, name: "M Train", color: 0xFF6319, striped: false },
+        // Eighth Avenue Line
+        { index: 17, name: "A Train", color: 0x0039A6, striped: false },
+        { index: 18, name: "C Train", color: 0x0039A6, striped: false },
+        { index: 19, name: "E Train", color: 0x0039A6, striped: false },
+        // Canarsie Line
+        { index: 20, name: "L Train", color: 0xA7A9AC, striped: false },
+        // Crosstown Line
+        { index: 21, name: "G Train", color: 0x6CBE45, striped: false },
+        // Nassau Street Line
+        { index: 22, name: "J Train", color: 0x996633, striped: false },
+        { index: 23, name: "Z Train", color: 0x996633, striped: false },
+        // Shuttles
+        { index: 24, name: "S Shuttle", color: 0x808183, striped: false },
+        { index: 25, name: "SIR", color: 0x0039A6, striped: false },
+    ];
+
+    protected lineIdToIndex: { [key: string]: number } = {
+        '1': 0, '2': 1, '3': 2,
+        '4': 3, '5': 4, '6': 5, '6X': 6,
+        '7': 7, '7X': 8,
+        'N': 9, 'Q': 10, 'R': 11, 'W': 12,
+        'B': 13, 'D': 14, 'F': 15, 'M': 16,
+        'A': 17, 'C': 18, 'E': 19,
+        'L': 20, 'G': 21,
+        'J': 22, 'Z': 23,
+        'S': 24, 'FS': 24, 'H': 24, 'GS': 24,
+        'SI': 25, 'SIR': 25,
+    };
+
+    /**
+     * Map MTA alert type to StatusSeverity
+     */
+    protected mapSeverity(alertType: string): StatusSeverity {
+        if (alertType.includes('No Scheduled Service') ||
+            alertType.includes('Suspension') ||
+            alertType.includes('No Service')) {
+            return StatusSeverity.Severe;
+        } else if (alertType.includes('Delay') ||
+            alertType.includes('Service Change') ||
+            alertType.includes('Planned Work')) {
+            return StatusSeverity.Warning;
+        } else if (alertType.includes('Extra Service')) {
+            return StatusSeverity.Good;
+        }
+        return StatusSeverity.Warning;
+    }
+
+    /**
+     * Check if an alert is currently active based on its active periods
+     * MTA sometimes returns alerts with future active periods only as planned work
+     */
+    private isAlertActive(activePeriods: Array<{ start: number, end: number }>): boolean {
+        if (!activePeriods || activePeriods.length === 0) return true;
+
+        const now = Math.floor(Date.now() / 1000);
+
+        for (const period of activePeriods) {
+            if (now >= period.start && now <= period.end) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Shorten alert type for display
+     */
+    private formatAlertType(type: string): string {
+        if (type === 'No Scheduled Service') return 'No Service';
+        if (type.startsWith('Planned - ')) return type.substring(10);
+        if (type === 'Station Notice') return 'Notice';
+        return type || 'Service Alert';
+    }
+
+    /**
+     * Fetch current line statuses from MTA API
+     */
+    async fetchLines(): Promise<LineStatus[] & { configMapping: number[] }> {
+        try {
+            const data = await PebbleTS.fetchJSON<{ entity: MTAAlertEntity[] }>(this.apiUrl);
+
+            if (!data.entity) {
+                console.warn('No entities in response');
+                return this.emptyResult();
+            }
+
+            const routeIssues: { [routeId: string]: RouteIssue } = {};
+
+            for (const entity of data.entity) {
+                if (!entity.alert) continue;
+
+                const { alert } = entity;
+                if (alert.active_period && !this.isAlertActive(alert.active_period)) {
+                    continue; // Not active
+                }
+
+                const impactedRoutes = new Set<string>();
+                if (alert.informed_entity) {
+                    for (const informed of alert.informed_entity) {
+                        if (informed.route_id) {
+                            impactedRoutes.add(informed.route_id);
+                        }
+                    }
+                }
+
+                if (impactedRoutes.size === 0) continue;
+
+                // TODO: Handle localization
+                // Using the first translation text available, probably English
+                const alertText = alert.header_text?.translation?.[0]?.text || '';
+                const alertType = alert['transit_realtime.mercury_alert']?.alert_type || '';
+                const severity = this.mapSeverity(alertType);
+
+                for (const routeId of impactedRoutes) {
+                    // Initialize route if this is the first alert
+                    if (!routeIssues[routeId]) {
+                        routeIssues[routeId] = { type: alertType, descriptions: [], severity };
+                    }
+                    // If this alert is more severe, override type/severity
+                    else if (severity > routeIssues[routeId].severity) {
+                        routeIssues[routeId].type = alertType;
+                        routeIssues[routeId].severity = severity;
+                    }
+                    // Collect all alert descriptions for this route
+                    if (alertText) {
+                        routeIssues[routeId].descriptions.push(alertText);
+                    }
+                }
+            }
+
+            const result: Array<LineStatus & { configIndex: number }> = [];
+
+            for (const [routeId, issue] of Object.entries(routeIssues)) {
+                const configIndex = this.lineIdToIndex[routeId];
+                if (configIndex === undefined) {
+                    console.log(`Unknown route ID: ${routeId}`);
+                    continue;
+                }
+
+                if (issue.severity === StatusSeverity.Good) {
+                    continue;
+                }
+
+                const status = this.formatAlertType(issue.type);
+                const reason = this.truncateReason(issue.descriptions.join(' | '));
+
+                result.push({
+                    index: result.length,
+                    configIndex,
+                    status,
+                    severity: issue.severity,
+                    reason,
+                });
+            }
+
+            if (result.length === 0) {
+                return this.emptyResult();
+            }
+
+            // Add config mapping (maps sequential display indices to config indices)
+            const typedResult = result as unknown as LineStatus[] & { configMapping: number[] };
+            typedResult.configMapping = result.map(r => r.configIndex);
+            return typedResult;
+
+        } catch (error) {
+            console.log(`Error in fetchLines: ${error}`);
+            throw error;
+        }
+    }
+
+    /**
+     * Create empty result with configMapping
+     */
+    private emptyResult(): LineStatus[] & { configMapping: number[] } {
+        const empty = [] as unknown as LineStatus[] & { configMapping: number[] };
+        empty.configMapping = [];
+        return empty;
+    }
+}
+
+/**
+ * Export singleton instance
+ */
+export const nycMtaSubwayBackend = new NycMtaSubwayBackend();

--- a/watchapps/tube-status/src/ts/backends/nycmtasubway.ts
+++ b/watchapps/tube-status/src/ts/backends/nycmtasubway.ts
@@ -24,7 +24,8 @@ interface RouteIssue {
  */
 class NycMtaSubwayBackend extends TransitBackend {
     readonly id = 'nyc';
-    readonly name = 'NYC MTA Subway';
+    readonly name = 'MTA Subway';
+    readonly region = 'NYC, USA';
 
     private readonly apiUrl = 'https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts.json';
 

--- a/watchapps/tube-status/src/ts/backends/type.ts
+++ b/watchapps/tube-status/src/ts/backends/type.ts
@@ -35,6 +35,7 @@ export type LineStatus = {
 export abstract class TransitBackend {
   abstract readonly id: string;
   abstract readonly name: string;
+  abstract readonly region: string;
 
   protected abstract lineConfigs: LineConfig[];
   protected abstract lineIdToIndex: { [key: string]: number };

--- a/watchapps/tube-status/src/ts/backends/type.ts
+++ b/watchapps/tube-status/src/ts/backends/type.ts
@@ -1,0 +1,57 @@
+const MAX_REASON_LENGTH = 512;
+
+/**
+ * Status severity levels
+ */
+export enum StatusSeverity {
+  Good = 0,
+  Warning = 1,
+  Severe = 2
+}
+
+/**
+ * Line configuration
+ */
+export type LineConfig = {
+  index: number;
+  name: string;
+  color: number;      // Hex color as uint32
+  striped: boolean;   // Renders a visual difference, can be used to indicate special lines
+};
+
+/**
+ * Line status data
+ */
+export type LineStatus = {
+  index: number;
+  status: string;
+  severity: StatusSeverity;
+  reason: string;
+};
+
+/**
+ * Base abstract class for transit backends
+ */
+export abstract class TransitBackend {
+  abstract readonly id: string;
+  abstract readonly name: string;
+
+  protected abstract lineConfigs: LineConfig[];
+  protected abstract lineIdToIndex: { [key: string]: number };
+
+
+  getLineConfigs(): LineConfig[] {
+    return this.lineConfigs;
+  }
+
+  abstract fetchLines(): Promise<LineStatus[] & { configMapping: number[] }>;
+
+  protected abstract mapSeverity(input: string | number): StatusSeverity;
+
+  protected truncateReason(reason: string): string {
+    if (reason.length > MAX_REASON_LENGTH) {
+      return reason.substring(0, MAX_REASON_LENGTH - 4) + '...';
+    }
+    return reason;
+  }
+}

--- a/watchapps/tube-status/src/ts/backends/type.ts
+++ b/watchapps/tube-status/src/ts/backends/type.ts
@@ -46,7 +46,7 @@ export abstract class TransitBackend {
 
   abstract fetchLines(): Promise<LineStatus[] & { configMapping: number[] }>;
 
-  protected abstract mapSeverity(input: string | number): StatusSeverity;
+  protected abstract mapSeverity(...args: any[]): StatusSeverity;
 
   protected truncateReason(reason: string): string {
     if (reason.length > MAX_REASON_LENGTH) {

--- a/watchapps/tube-status/src/ts/index.ts
+++ b/watchapps/tube-status/src/ts/index.ts
@@ -1,7 +1,7 @@
-import { type TransitBackend, type LineConfig, type GenericLineData, londonUndergroundBackend } from './backends';
+import { type TransitBackend, type LineConfig, type GenericLineData, jrEastKantoBackend } from './backends';
 
 // TODO: Configure ACTIVE_BACKEND with settings in the future
-const ACTIVE_BACKEND: TransitBackend = londonUndergroundBackend;
+const ACTIVE_BACKEND: TransitBackend = jrEastKantoBackend;
 
 /**
  * Send line configurations to the watch

--- a/watchapps/tube-status/src/ts/index.ts
+++ b/watchapps/tube-status/src/ts/index.ts
@@ -1,7 +1,13 @@
-import { type TransitBackend, type LineConfig, type GenericLineData, jrEastKantoBackend } from './backends';
+import { type LineConfig, type GenericLineData, jrEastKantoBackend, londonUndergroundBackend, nycMtaSubwayBackend, TransitBackend } from './backends';
 
-// TODO: Configure ACTIVE_BACKEND with settings in the future
-const ACTIVE_BACKEND: TransitBackend = jrEastKantoBackend;
+// Order can be changed, Tube Status uses -1 to indicate London Underground
+const TransitBackendIdMap: Record<number, TransitBackend> = {
+  0: londonUndergroundBackend,
+  1: jrEastKantoBackend,
+  2: nycMtaSubwayBackend
+} as const;
+
+let ACTIVE_BACKEND: TransitBackend = londonUndergroundBackend;
 
 /**
  * Send line configurations to the watch
@@ -11,6 +17,7 @@ const sendLineConfigs = async (configs: LineConfig[]): Promise<void> => {
 
   for (const config of configs) {
     const dict = {
+      Type: 'lineConfig',
       ConfigLineIndex: config.index,
       ConfigLineName: config.name,
       ConfigLineColor: config.color,
@@ -30,6 +37,7 @@ const sendLineStatuses = async (lines: GenericLineData[]): Promise<void> => {
   // Everything is awesome!
   if (lines.length === 0) {
     const dict = {
+      Type: 'lineStatus',
       FlagIsComplete: 1,
       FlagLineCount: 0,
     };
@@ -41,6 +49,7 @@ const sendLineStatuses = async (lines: GenericLineData[]): Promise<void> => {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const dict = {
+      Type: 'lineStatus',
       LineStatusIndex: i,
       LineStatus: line.status,
       LineStatusSeverity: line.severity,
@@ -55,33 +64,79 @@ const sendLineStatuses = async (lines: GenericLineData[]): Promise<void> => {
   console.log('All status updates sent!');
 };
 
-Pebble.addEventListener('ready', async (e) => {
+/**
+ * Send all available transit systems to the watch with completion flag
+ */
+const sendAvailableTransitSystems = async (transitSystems: Record<number, TransitBackend>) => {
+  const transitSystemBackendTotal = Object.keys(transitSystems).length;
+  Object.entries(transitSystems).forEach(async ([id, backend]) => {
+    const dict = {
+      Type: 'availableTransitSystem',
+      AvailableTransitSystemIndex: parseInt(id),
+      AvailableTransitSystemName: backend.name,
+      AvailableTransitSystemRegion: backend.region,
+      FlagLineCount: transitSystemBackendTotal,
+      FlagIsComplete: parseInt(id) === (transitSystemBackendTotal - 1) ? 1 : 0,
+    };
+    await PebbleTS.sendAppMessage(dict);
+    console.log(`Sent available transit system: ${backend.name} (ID: ${id})`);
+  });
+};
+
+Pebble.addEventListener('ready', async (_) => {
   console.log('PebbleKit JS ready');
-  console.log(`Active backend: ${ACTIVE_BACKEND.name}`);
+  PebbleTS.sendAppMessage({ Type: 'ready' });
+});
 
-  try {
-    // Fetch lines with issues first
-    const lines = await ACTIVE_BACKEND.fetchLines();
+Pebble.addEventListener('appmessage', async (e) => {
+  if (!e.payload) {
+    return;
+  }
 
-    // Only send configs for lines that have issues
-    if (lines.length > 0) {
-      const allConfigs = ACTIVE_BACKEND.getLineConfigs();
+  console.log(JSON.stringify(e.payload));
+  if (e.payload.RequestAvailableTransitSystems) {
+    sendAvailableTransitSystems(TransitBackendIdMap);
+    return;
+  }
 
-      const neededConfigs = lines.configMapping.map((configIndex: number, displayIndex: number) => {
-        const config = allConfigs[configIndex];
-        return { ...config, index: displayIndex }; // Remap to sequential index
-      });
-
-      console.log(`Sending configs for ${neededConfigs.length} lines with issues (out of ${allConfigs.length} total)`);
-      await sendLineConfigs(neededConfigs);
+  // This is a 0 index, possible negative, based ID so we should not truthy check it
+  if (e.payload.RequestTransitSystem !== undefined) {
+    if (e.payload.RequestTransitSystem === -1) {
+      ACTIVE_BACKEND = londonUndergroundBackend;
     } else {
-      console.log('No issues detected, skipping line configurations');
+      ACTIVE_BACKEND = TransitBackendIdMap[e.payload.RequestTransitSystem];
+      if (!ACTIVE_BACKEND) {
+        console.log(`No backend found for transit system ID: ${e.payload.RequestTransitSystem}`);
+        ACTIVE_BACKEND = londonUndergroundBackend;
+      }
     }
 
-    // Send status updates
-    await sendLineStatuses(lines);
-  } catch (e) {
-    console.log('Failed to send data');
-    console.log(e);
+    console.log(`Active backend: ${ACTIVE_BACKEND.name}`);
+
+    try {
+      // Fetch lines with issues first
+      const lines = await ACTIVE_BACKEND.fetchLines();
+
+      // Only send configs for lines that have issues
+      if (lines.length > 0) {
+        const allConfigs = ACTIVE_BACKEND.getLineConfigs();
+
+        const neededConfigs = lines.configMapping.map((configIndex: number, displayIndex: number) => {
+          const config = allConfigs[configIndex];
+          return { ...config, index: displayIndex }; // Remap to sequential index
+        });
+
+        console.log(`Sending configs for ${neededConfigs.length} lines with issues (out of ${allConfigs.length} total)`);
+        await sendLineConfigs(neededConfigs);
+      } else {
+        console.log('No issues detected, skipping line configurations');
+      }
+
+      // Send status updates
+      await sendLineStatuses(lines);
+    } catch (e) {
+      console.log('Failed to send data');
+      console.log(e);
+    }
   }
 });

--- a/watchapps/tube-status/wscript
+++ b/watchapps/tube-status/wscript
@@ -3,14 +3,47 @@
 #
 # Feel free to customize this to your needs.
 #
+import json
 import os.path
 
 top = '.'
 out = 'build'
 
+def variant_setup(ctx):
+    variant = ctx.options.variant
+    if variant == 'transit_status' and not os.path.exists('package.json.bak'):
+        ctx.env.append_value('DEFINES', ['APP_VARIANT_TRANSIT_STATUS'])
+
+        ctx.exec_command('cp package.json package.json.bak')
+
+        with open('package.json', 'r') as f:
+            base = json.load(f)
+        with open('package-transit_status.json', 'r') as f:
+            override = json.load(f)
+
+        for key, value in override.items():
+            if isinstance(value, dict) and key in base and isinstance(base[key], dict):
+                base[key].update(value)
+            else:
+                base[key] = value
+
+        with open('package.json', 'w') as f:
+            json.dump(base, f, indent=2)
+
+        ctx.exec_command('npm install')
+    else:
+        ctx.env.append_value('DEFINES', ['APP_VARIANT_TUBE_STATUS'])
+
+def variant_reset(ctx):
+    variant = ctx.options.variant
+    if variant == 'transit_status' and os.path.exists('package.json.bak'):
+        ctx.exec_command('mv package.json.bak package.json')
+        ctx.exec_command('npm install')
 
 def options(ctx):
     ctx.load('pebble_sdk')
+    ctx.add_option('--variant', action='store', default='default',
+                   help='Build variant: default or transit_status')
 
 
 def configure(ctx):
@@ -20,37 +53,46 @@ def configure(ctx):
     change after calling ctx.load('pebble_sdk') and make sure to set the correct environment first.
     Universal configuration: add your change prior to calling ctx.load('pebble_sdk').
     """
-    ctx.load('pebble_sdk')
+    try:
+        variant_setup(ctx)
+        ctx.load('pebble_sdk')
+    finally:
+        variant_reset(ctx)
 
 
 def build(ctx):
-    ctx.exec_command('npm run build')
+    try:
+        variant_setup(ctx)
+        
+        ctx.exec_command('npm run build')
 
-    ctx.load('pebble_sdk')
+        ctx.load('pebble_sdk')
 
-    build_worker = os.path.exists('worker_src')
-    binaries = []
+        build_worker = os.path.exists('worker_src')
+        binaries = []
 
-    cached_env = ctx.env
-    for platform in ctx.env.TARGET_PLATFORMS:
-        ctx.env = ctx.all_envs[platform]
-        ctx.set_group(ctx.env.PLATFORM_NAME)
-        app_elf = '{}/pebble-app.elf'.format(ctx.env.BUILD_DIR)
-        ctx.pbl_build(source=ctx.path.ant_glob('src/c/**/*.c'), target=app_elf, bin_type='app')
+        cached_env = ctx.env
+        for platform in ctx.env.TARGET_PLATFORMS:
+            ctx.env = ctx.all_envs[platform]
+            ctx.set_group(ctx.env.PLATFORM_NAME)
+            app_elf = '{}/pebble-app.elf'.format(ctx.env.BUILD_DIR)
+            ctx.pbl_build(source=ctx.path.ant_glob('src/c/**/*.c'), target=app_elf, bin_type='app')
 
-        if build_worker:
-            worker_elf = '{}/pebble-worker.elf'.format(ctx.env.BUILD_DIR)
-            binaries.append({'platform': platform, 'app_elf': app_elf, 'worker_elf': worker_elf})
-            ctx.pbl_build(source=ctx.path.ant_glob('worker_src/c/**/*.c'),
-                          target=worker_elf,
-                          bin_type='worker')
-        else:
-            binaries.append({'platform': platform, 'app_elf': app_elf})
-    ctx.env = cached_env
+            if build_worker:
+                worker_elf = '{}/pebble-worker.elf'.format(ctx.env.BUILD_DIR)
+                binaries.append({'platform': platform, 'app_elf': app_elf, 'worker_elf': worker_elf})
+                ctx.pbl_build(source=ctx.path.ant_glob('worker_src/c/**/*.c'),
+                            target=worker_elf,
+                            bin_type='worker')
+            else:
+                binaries.append({'platform': platform, 'app_elf': app_elf})
+        ctx.env = cached_env
 
-    ctx.set_group('bundle')
-    ctx.pbl_bundle(binaries=binaries,
-                   js=ctx.path.ant_glob(['src/ts-build/**/*.js',
-                                         'src/pkjs/**/*.json',
-                                         'src/common/**/*.js']),
-                   js_entry_file='src/ts-build/index.js')
+        ctx.set_group('bundle')
+        ctx.pbl_bundle(binaries=binaries,
+                    js=ctx.path.ant_glob(['src/ts-build/**/*.js',
+                                            'src/pkjs/**/*.json',
+                                            'src/common/**/*.js']),
+                    js_entry_file='src/ts-build/index.js')
+    finally:
+        variant_reset(ctx)


### PR DESCRIPTION
[WIP]

## Overview

This is going to be the complete POC for this project which includes:
- Making Tube Status generic in the watch code so it does not have to understand that it is loading data for any specific transit system (TfL in this case)
- Adding a generic interface to the phone code so that any backend system can conform to a structure that the phone and watch can load with the expected results
  - As a concept, TfL, JR Kanto East, and NYC MTA Subway are included as first examples of how three different systems can conform to the required interface
- Creating a way to select a transit system to display
  - The first time a user opens the app, it should prompt them to select a transit system
  - The select transit system should be stored on the watch persistently so it does not need to prompt again on future startups
  - There should be a mechanism on the watch itself to change the transit system
- Creating a mechanism in which Tube Status can continue to be built and function identically to how it does today
- Creating a mechanism in which "Transit Status" (the working name) can be built, allowing all the functionality of switching transit systems without affecting Tube Status

## Data Flow

A primary goal of mine is to impact Tube Status in ways that only benefit the code for it without letting Transit Status muddy the implementation. Generifying the watch code and restructuring the routes in which the data flows should be beneficial to Tube Status on its own, even if Transit Status never came to fruition. Below are two diagrams to show how Tube Status and Transit Status can benefit from the same data flow.

<img width="960" height="344" alt="image" src="https://github.com/user-attachments/assets/082763f5-b196-46f9-bf98-53860b507c6b" />
----------
<img width="1006" height="416" alt="image" src="https://github.com/user-attachments/assets/3467635c-8a58-44ff-89b8-ff3029685e38" />

You can see between these two sequences, the only different is that Transit Status has a process to allow the user to select a Transit System, whereas Tube Status will always just request TfL. The data flow is identical from that point onwards.

## TODO:
- [ ] Store the selected transit system persistently on the watch
- [ ] Decide on and implement a mechanism for showing the the transit selection screen again
- [ ] Clean up the initial loading screen that appears before the transit selection is shown. It is so fast it feels like a jitter
- [ ] Split the new build process out to its own script

## Build
Build Tube Status with:
`pebble build` (this is the default behavior of build

Build Transit Status with:
`pebble build -- --variant=transit_status` (will reset the local state back to Tube Status after build is complete)

The build process works entirely inside of the wscript, though it should probably be split out into its own script (in the TODOs). The package-tube_status.json file only overrides values from package.json during build time. Overrides are also at the top level, so you can't append things like MessageKeys, you'd have to duplicate the entire list from package.json if you want to do that.

Internally in the build process, the transit status JSON is merged with the default, npm install is run, and the build proceeds. After the process finishes, it puts the original package.json back and runs npm install again to put it back into the Tube Status configuration.