### PR TITLE
[pebble-isometric] Fix Chalk (+maybe Gabbro) crash on real hardware

### DIFF
--- a/libraries/pebble-isometric/src/c/pebble-isometric.c
+++ b/libraries/pebble-isometric/src/c/pebble-isometric.c
@@ -32,9 +32,26 @@ static void bresenham_line(GPoint start, GPoint finish, GColor color) {
   int err = ((dx > dy) ? dx : -dy) / 2;
   int e2;
 
+  // Don't draw lines that won't appear on-screen
+  if ((start.y < 0 && finish.y < 0) || (start.y >= s_fb_size.h && finish.y >= s_fb_size.h)) {
+    return; 
+  }
+  
+  #if PBL_ROUND
+  // Chalk (and possibly Gabbro) really hate when you use
+  // gbitmap_get_data_row_info() on a negative row number;
+  // doing this causes a crash (on real hardware only).
+  if (start.y >= 0) s_info = gbitmap_get_data_row_info(s_fb, start.y);
+  #else
   s_info = gbitmap_get_data_row_info(s_fb, start.y);
+  #endif
+  
   while (true) {
+    #if PBL_ROUND
+    if (start.y >= 0) set_pixel(GPoint(start.x, start.y), color);
+    #else
     set_pixel(GPoint(start.x, start.y), color);
+    #endif
     if (start.x == finish.x && start.y == finish.y) break;
 
     e2 = err;
@@ -45,7 +62,12 @@ static void bresenham_line(GPoint start, GPoint finish, GColor color) {
     if (e2 < dy) {
       err += dx;
       start.y += sy;
+      
+      #if PBL_ROUND
+      if (start.y >= 0) s_info = gbitmap_get_data_row_info(s_fb, start.y);
+      #else
       s_info = gbitmap_get_data_row_info(s_fb, start.y);
+      #endif
     }
   }
 }


### PR DESCRIPTION
This PR fixes an issue in the `pebble-isometric` library that led to a crash on Chalk hardware in the patchwork watchface (may impact Gabbro as well, but obviously very few people can test this right now).

The crash this fixes only appears on hardware (not present in the emulator). Giving `gbitmap_get_data_row_info()` a negative value for the y-index of a row causes an immediate crash. There may be a better long-term solution, but in my testing, just skipping the call to `gbitmap_get_data_row_info()` on round watches when y is negative fixes the issue and doesn't appear to cause any visual issues.

I also added in logic to avoid drawing lines that won't appear on the screen at all (from adding an APP_LOG to where I am checking for this, I did indeed see this happening in patchwork).

The part where I am avoiding `set_pixel` is not actually necessary to avoid the crash. I figured since it's off-screen anyway, there's no need to do this, but I'm still not sure if adding a check there is really worth it.